### PR TITLE
Remove inner classes.

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -5,6 +5,7 @@ plugins {
     `maven-publish`
     signing
     alias(libs.plugins.jreleaser)
+    alias(libs.plugins.spotless)
 }
 
 group = "com.mussonindustrial"
@@ -27,6 +28,18 @@ java {
     sourceCompatibility = JavaVersion.VERSION_17
     withJavadocJar()
     withSourcesJar()
+}
+
+spotless {
+    java {
+        importOrder()
+        removeUnusedImports()
+        palantirJavaFormat()
+    }
+}
+
+tasks.build {
+    dependsOn(tasks.spotlessCheck)
 }
 
 tasks.withType(Test::class).configureEach {

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -4,6 +4,7 @@ junit-platform = "1.11.0"
 junit-jupiter = "5.11.0"
 slf4j = "2.0.16"
 jreleaser = "1.13.1"
+spotless = "6.25.0"
 
 [libraries]
 testcontainers = { module = "org.testcontainers:testcontainers", version.ref = "testcontainers"}
@@ -13,3 +14,4 @@ slf4j = { module = "org.slf4j:slf4j-simple", version.ref = "slf4j"}
 
 [plugins]
 jreleaser = { id = "org.jreleaser", version.ref = "jreleaser" }
+spotless = { id = "com.diffplug.spotless", version.ref = "spotless" }

--- a/src/main/java/com/mussonindustrial/testcontainers/ignition/GatewayEdition.java
+++ b/src/main/java/com/mussonindustrial/testcontainers/ignition/GatewayEdition.java
@@ -1,25 +1,18 @@
 package com.mussonindustrial.testcontainers.ignition;
 
-/**
- * Gateway Editions
- */
+/** Gateway Editions */
 public enum GatewayEdition {
-    /**
-     * Standard Edition
-    */
+    /** Standard Edition */
     STANDARD("standard"),
 
-    /**
-     * Edge Edition
-     */
+    /** Edge Edition */
     EDGE("edge"),
 
-    /**
-     * Maker Edition
-     */
+    /** Maker Edition */
     MAKER("maker");
 
     private final String value;
+
     GatewayEdition(String value) {
         this.value = value;
     }

--- a/src/main/java/com/mussonindustrial/testcontainers/ignition/IgnitionContainer.java
+++ b/src/main/java/com/mussonindustrial/testcontainers/ignition/IgnitionContainer.java
@@ -382,7 +382,7 @@ public class IgnitionContainer extends GenericContainer<IgnitionContainer> {
      * @return the mapped gateway HTTPS port.
      */
     @SuppressWarnings("unused")
-    public int getMappedGatewaySSLPort() {
+    public int getMappedGatewaySslPort() {
         return getMappedPort(GATEWAY_SSL_PORT);
     }
 
@@ -435,7 +435,7 @@ public class IgnitionContainer extends GenericContainer<IgnitionContainer> {
     @SuppressWarnings("unused")
     public String getGatewayUrl(boolean ssl) {
         String mode = ssl ? "https" : "http";
-        Integer port = ssl ? getMappedGatewaySSLPort() : getMappedGatewayPort();
+        Integer port = ssl ? getMappedGatewaySslPort() : getMappedGatewayPort();
         return String.format("%s://%s:%d", mode, getHost(), port);
     }
 

--- a/src/main/java/com/mussonindustrial/testcontainers/ignition/IgnitionContainer.java
+++ b/src/main/java/com/mussonindustrial/testcontainers/ignition/IgnitionContainer.java
@@ -15,12 +15,12 @@ import org.testcontainers.utility.MountableFile;
  *
  * <p> Supported image: {@code inductiveautomation/ignition}
  * <p> Exposed ports:
- *
  * <ul>
- * <li>Gateway: 8080
- * <li>Gateway (SSL): 8043
- * <li>GAN: 8060
- * <li>JVM Debugger: 8000
+ * <li>Gateway: 8080</li>
+ * <li>Gateway (SSL): 8043</li>
+ * <li>GAN: 8060</li>
+ * <li>OPC-UA Server: 62541</li>
+ * <li>JVM Debugger: 8000</li>
  * </ul>
  */
 public class IgnitionContainer extends GenericContainer<IgnitionContainer> {

--- a/src/main/java/com/mussonindustrial/testcontainers/ignition/IgnitionContainer.java
+++ b/src/main/java/com/mussonindustrial/testcontainers/ignition/IgnitionContainer.java
@@ -429,13 +429,13 @@ public class IgnitionContainer extends GenericContainer<IgnitionContainer> {
     /**
      * Get the URL of the gateway web interface.
      *
-     * @param useHttps use HTTPS when `true`
+     * @param ssl use HTTPS when `true`
      * @return the URL of the gateway web interface.
      */
     @SuppressWarnings("unused")
-    public String getGatewayUrl(boolean useHttps) {
-        String mode = useHttps ? "https" : "http";
-        Integer port = useHttps ? getMappedGatewaySSLPort() : getMappedGatewayPort();
+    public String getGatewayUrl(boolean ssl) {
+        String mode = ssl ? "https" : "http";
+        Integer port = ssl ? getMappedGatewaySSLPort() : getMappedGatewayPort();
         return String.format("%s://%s:%d", mode, getHost(), port);
     }
 

--- a/src/main/java/com/mussonindustrial/testcontainers/ignition/IgnitionContainer.java
+++ b/src/main/java/com/mussonindustrial/testcontainers/ignition/IgnitionContainer.java
@@ -30,7 +30,7 @@ public class IgnitionContainer extends GenericContainer<IgnitionContainer> {
     private static final Integer GATEWAY_PORT = 8088;
     private static final Integer GATEWAY_SSL_PORT = 8043;
     private static final Integer GAN_PORT = 8060;
-    private static final Integer OPCUA_PORT = 8000;
+    private static final Integer OPCUA_PORT = 62541;
     private static final Integer DEBUG_PORT = 8000;
     private static final String INSTALL_DIR = "/usr/local/bin/ignition";
 

--- a/src/main/java/com/mussonindustrial/testcontainers/ignition/IgnitionContainer.java
+++ b/src/main/java/com/mussonindustrial/testcontainers/ignition/IgnitionContainer.java
@@ -269,8 +269,9 @@ public class IgnitionContainer extends GenericContainer<IgnitionContainer> {
      * @return this {@link IgnitionContainer} for chaining purposes.
      */
     @SuppressWarnings("unused")
-    public IgnitionContainer withModule(Module... modules) {
+    public IgnitionContainer withModules(Module... modules) {
         checkNotRunning();
+        this.modules.clear();
         this.modules.addAll(List.of(modules));
         return self();
     }
@@ -283,8 +284,9 @@ public class IgnitionContainer extends GenericContainer<IgnitionContainer> {
      * @throws FileNotFoundException if a module path does not exist.
      */
     @SuppressWarnings("unused")
-    public IgnitionContainer withThirdPartyModule(Path... paths) throws FileNotFoundException {
+    public IgnitionContainer withThirdPartyModules(Path... paths) throws FileNotFoundException {
         checkNotRunning();
+        this.thirdPartyModules.clear();
 
         for (Path path : paths) {
             if (!path.toFile().exists()) {
@@ -303,8 +305,8 @@ public class IgnitionContainer extends GenericContainer<IgnitionContainer> {
      * @return this {@link IgnitionContainer} for chaining purposes.
      * @throws FileNotFoundException if a module path does not exist.
      */
-    public IgnitionContainer withThirdPartyModule(String... paths) throws FileNotFoundException {
-        return this.withThirdPartyModule(Arrays.stream(paths).map(Path::of).toArray(Path[]::new));
+    public IgnitionContainer withThirdPartyModules(String... paths) throws FileNotFoundException {
+        return this.withThirdPartyModules(Arrays.stream(paths).map(Path::of).toArray(Path[]::new));
     }
 
     /**

--- a/src/main/java/com/mussonindustrial/testcontainers/ignition/IgnitionContainer.java
+++ b/src/main/java/com/mussonindustrial/testcontainers/ignition/IgnitionContainer.java
@@ -1,28 +1,26 @@
 package com.mussonindustrial.testcontainers.ignition;
 
 import com.github.dockerjava.api.command.InspectContainerResponse;
+import java.io.FileNotFoundException;
+import java.nio.file.Path;
+import java.util.*;
+import java.util.stream.Collectors;
 import org.testcontainers.containers.GenericContainer;
 import org.testcontainers.containers.wait.strategy.Wait;
 import org.testcontainers.utility.DockerImageName;
 import org.testcontainers.utility.MountableFile;
 
-import java.io.FileNotFoundException;
-import java.nio.file.Path;
-import java.util.*;
-import java.util.stream.Collectors;
-
-
 /**
  * Testcontainers implementation for Ignition.
- * <p>
- * Supported image: {@code inductiveautomation/ignition}
- * <p>
- * Exposed ports:
+ *
+ * <p> Supported image: {@code inductiveautomation/ignition}
+ * <p> Exposed ports:
+ *
  * <ul>
- *     <li>Gateway: 8080</li>
- *     <li>Gateway (SSL): 8043</li>
- *     <li>GAN: 8060</li>
- *     <li>JVM Debugger: 8000</li>
+ * <li>Gateway: 8080
+ * <li>Gateway (SSL): 8043
+ * <li>GAN: 8060
+ * <li>JVM Debugger: 8000
  * </ul>
  */
 public class IgnitionContainer extends GenericContainer<IgnitionContainer> {
@@ -68,10 +66,9 @@ public class IgnitionContainer extends GenericContainer<IgnitionContainer> {
 
     private String licenseKey;
 
-
-
     /**
      * Creates a new Ignition container with the default image and version.
+     *
      * @deprecated use {@link #IgnitionContainer(DockerImageName)} instead
      */
     @Deprecated
@@ -90,6 +87,7 @@ public class IgnitionContainer extends GenericContainer<IgnitionContainer> {
 
     /**
      * Create a new Ignition container with the specified image name.
+     *
      * @param dockerImageName the image name that should be used.
      */
     public IgnitionContainer(final DockerImageName dockerImageName) {
@@ -155,6 +153,32 @@ public class IgnitionContainer extends GenericContainer<IgnitionContainer> {
 
     /**
      * Set a gateway backup file (*.gwbk) to restore from.
+     * Restores into the enabled state.
+     *
+     * @param path the path to the gateway backup file.
+     * @return this {@link IgnitionContainer} for chaining purposes.
+     * @throws FileNotFoundException if the gateway backup does not exist.
+     */
+    @SuppressWarnings("unused")
+    public IgnitionContainer withGatewayBackup(Path path) throws FileNotFoundException {
+        return this.withGatewayBackup(path, false);
+    }
+
+    /**
+     * Set a gateway backup file (*.gwbk) to restore from.
+     * Restores into the enabled state.
+     *
+     * @param path the path to the gateway backup file.
+     * @return this {@link IgnitionContainer} for chaining purposes.
+     * @throws FileNotFoundException if the gateway backup does not exist.
+     */
+    @SuppressWarnings("unused")
+    public IgnitionContainer withGatewayBackup(String path) throws FileNotFoundException {
+        return this.withGatewayBackup(path, false);
+    }
+
+    /**
+     * Set a gateway backup file (*.gwbk) to restore from.
      *
      * @param path the path to the gateway backup file.
      * @param restoreDisabled true to restore to a disabled state.
@@ -164,7 +188,6 @@ public class IgnitionContainer extends GenericContainer<IgnitionContainer> {
     @SuppressWarnings("unused")
     public IgnitionContainer withGatewayBackup(Path path, boolean restoreDisabled) throws FileNotFoundException {
         checkNotRunning();
-
 
         if (!path.toFile().exists()) {
             throw new FileNotFoundException(String.format("gateway backup '%s' does not exist", path));
@@ -263,7 +286,7 @@ public class IgnitionContainer extends GenericContainer<IgnitionContainer> {
     public IgnitionContainer withThirdPartyModule(Path... paths) throws FileNotFoundException {
         checkNotRunning();
 
-        for (Path path: paths) {
+        for (Path path : paths) {
             if (!path.toFile().exists()) {
                 throw new FileNotFoundException(String.format("module '%s' does not exist", path));
             }
@@ -384,6 +407,16 @@ public class IgnitionContainer extends GenericContainer<IgnitionContainer> {
     }
 
     /**
+     * Get the mapped OPC-UA server port.
+     *
+     * @return the mapped OPC-USA server port.
+     */
+    @SuppressWarnings("unused")
+    public int getMappedOpcUaPort() {
+        return getMappedPort(OPCUA_PORT);
+    }
+
+    /**
      * Get the URL of the gateway web interface (using HTTP).
      *
      * @return the URL of the gateway web interface.
@@ -395,8 +428,8 @@ public class IgnitionContainer extends GenericContainer<IgnitionContainer> {
 
     /**
      * Get the URL of the gateway web interface.
-     * @param useHttps use HTTPS when `true`
      *
+     * @param useHttps use HTTPS when `true`
      * @return the URL of the gateway web interface.
      */
     @SuppressWarnings("unused")
@@ -407,7 +440,8 @@ public class IgnitionContainer extends GenericContainer<IgnitionContainer> {
     }
 
     /**
-     * Checks if already running and if so raises an exception to prevent too-late setters.
+     * Checks if already running and if so raises an exception to prevent too-late
+     * setters.
      */
     private void checkNotRunning() {
         if (isRunning()) {
@@ -451,9 +485,11 @@ public class IgnitionContainer extends GenericContainer<IgnitionContainer> {
     }
 
     private void mapThirdPartyModules() {
-        for (Path path: thirdPartyModules) {
+        for (Path path : thirdPartyModules) {
             MountableFile file = MountableFile.forHostPath(path);
-            String containerPath = Path.of(INSTALL_DIR, "user-lib", "modules", path.toFile().getName()).toString();
+            String containerPath = Path.of(
+                            INSTALL_DIR, "user-lib", "modules", path.toFile().getName())
+                    .toString();
             this.withCopyFileToContainer(file, containerPath);
         }
     }
@@ -471,7 +507,9 @@ public class IgnitionContainer extends GenericContainer<IgnitionContainer> {
         map.put("GATEWAY_HTTPS_PORT", String.valueOf(GATEWAY_SSL_PORT));
 
         if (gatewayBackup != null) map.put("GATEWAY_RESTORE_DISABLED", String.valueOf(restoreDisabled));
-        map.put("GATEWAY_MODULES_ENABLED", modules.stream().map(Objects::toString).collect(Collectors.joining(",")));
+        map.put(
+                "GATEWAY_MODULES_ENABLED",
+                modules.stream().map(Objects::toString).collect(Collectors.joining(",")));
 
         map.put("IGNITION_EDITION", edition.toString());
         if (gid != null) map.put("IGNITION_GID", gid.toString());
@@ -494,5 +532,4 @@ public class IgnitionContainer extends GenericContainer<IgnitionContainer> {
     protected void containerIsStarted(final InspectContainerResponse containerInfo) {
         logger().info("Ignition container is ready! Gateway Web UI is available at: {}", getGatewayUrl());
     }
-
 }

--- a/src/main/java/com/mussonindustrial/testcontainers/ignition/Module.java
+++ b/src/main/java/com/mussonindustrial/testcontainers/ignition/Module.java
@@ -1,147 +1,89 @@
 package com.mussonindustrial.testcontainers.ignition;
 
-/**
- * Ignition Modules
- */
+/** Ignition Modules */
 public enum Module {
-    /**
-     * Alarm Notification Module
-     */
+    /** Alarm Notification Module */
     ALARM_NOTIFICATION("alarm-notification"),
 
-    /**
-     * Allen-Bradley Drivers Module
-     */
+    /** Allen-Bradley Drivers Module */
     ALLEN_BRADLEY_DRIVERS("allen-bradley-drivers"),
 
-    /**
-     * BACNet Driver Module
-     */
+    /** BACNet Driver Module */
     BACNET_DRIVER("bacnet-driver"),
 
-    /**
-     * DNP3 Driver Module
-     */
+    /** DNP3 Driver Module */
     DNP3_DRIVER("dnp3-driver"),
 
-    /**
-     * DNP3 Driver V2 Module
-     */
+    /** DNP3 Driver V2 Module */
     DNP3_DRIVER_V2("dnp3-driver-v2"),
 
-    /**
-     * EAM Module
-     */
+    /** EAM Module */
     ENTERPRISE_ADMINISTRATION("enterprise-administration"),
 
-    /**
-     * IEC-61850 Driver Module
-     */
+    /** IEC-61850 Driver Module */
     IEC_61850_DRIVER("iec-61850-driver"),
 
-    /**
-     * Logix Driver Module
-     */
+    /** Logix Driver Module */
     LOGIX_DRIVER("logix-driver"),
 
-    /**
-     * Micro800 Driver Module
-     */
+    /** Micro800 Driver Module */
     MICRO800_DRIVER("micro800-driver"),
 
-    /**
-     * Mitsubishi Driver Module
-     */
+    /** Mitsubishi Driver Module */
     MITSUBISHI_DRIVER("mitsubishi-driver"),
 
-    /**
-     * Modbus Driver V2 Module
-     */
+    /** Modbus Driver V2 Module */
     MODBUS_DRIVER_V2("modbus-driver-v2"),
 
-    /**
-     * Omron Driver Module
-     */
+    /** Omron Driver Module */
     OMRON_DRIVER("omron-driver"),
 
-    /**
-     * OPC-UA Module
-     */
+    /** OPC-UA Module */
     OPC_UA("opc-ua"),
 
-    /**
-     * Perspective Module
-     */
+    /** Perspective Module */
     PERSPECTIVE("perspective"),
 
-    /**
-     * Reporting Module
-     */
+    /** Reporting Module */
     REPORTING("reporting"),
 
-    /**
-     * Client Serial Support Module
-     */
+    /** Client Serial Support Module */
     SERIAL_SUPPORT_CLIENT("serial-support-client"),
 
-    /**
-     * Gateway Serial Support Module
-     */
+    /** Gateway Serial Support Module */
     SERIAL_SUPPORT_GATEWAY("serial-support-gateway"),
 
-    /**
-     * Sequential Function Chart Module
-     */
+    /** Sequential Function Chart Module */
     SFC("sfc"),
 
-    /**
-     * Siemens Drivers Module
-     */
+    /** Siemens Drivers Module */
     SIEMENS_DRIVERS("siemens-drivers"),
 
-    /**
-     * SMS Notification Module
-     */
+    /** SMS Notification Module */
     SMS_NOTIFICATION("sms-notification"),
 
-    /**
-     * SQL Bridge Module
-     */
+    /** SQL Bridge Module */
     SQL_BRIDGE("sql-bridge"),
 
-    /**
-     * Symbol Factory Module
-     */
+    /** Symbol Factory Module */
     SYMBOL_FACTORY("symbol-factory"),
 
-    /**
-     * Tag Historian Module
-     */
+    /** Tag Historian Module */
     TAG_HISTORIAN("tag-historian"),
 
-    /**
-     * UDP/TCP Drivers Module
-     */
+    /** UDP/TCP Drivers Module */
     UDP_TCP_DRIVERS("udp-tcp-drivers"),
 
-    /**
-     * Vision Module
-     */
+    /** Vision Module */
     VISION("vision"),
 
-    /**
-     * Voice Notification Module
-     */
+    /** Voice Notification Module */
     VOICE_NOTIFICATION("voice-notification"),
 
-    /**
-     * Web Browser Module
-     */
+    /** Web Browser Module */
     WEB_BROWSER("web-browser"),
 
-    /**
-     * Web Development (WebDev) Module
-     */
+    /** Web Development (WebDev) Module */
     WEB_DEVELOPER("web-developer");
 
     private final String value;
@@ -155,4 +97,3 @@ public enum Module {
         return this.value;
     }
 }
-

--- a/src/test/java/com/mussonindustrial/testcontainers/ignition/GatewayBackupTest.java
+++ b/src/test/java/com/mussonindustrial/testcontainers/ignition/GatewayBackupTest.java
@@ -3,7 +3,8 @@ package com.mussonindustrial.testcontainers.ignition;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.parallel.Execution;
 import org.junit.jupiter.api.parallel.ExecutionMode;
-import org.testcontainers.containers.ContainerLaunchException;
+
+import java.io.FileNotFoundException;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
@@ -12,7 +13,7 @@ import static org.junit.jupiter.api.Assertions.assertThrows;
 public class GatewayBackupTest {
 
     @Test
-    public void useGatewayBackup() {
+    public void useGatewayBackup() throws FileNotFoundException {
         try (
                 IgnitionContainer ignition = new IgnitionContainer("inductiveautomation/ignition:8.1.33")
                         .withGatewayBackup("./src/test/resources/backup.gwbk", false)
@@ -23,13 +24,13 @@ public class GatewayBackupTest {
 
     @Test
     public void failWhenGatewayBackupNotPresent() {
-        ContainerLaunchException exception = assertThrows(ContainerLaunchException.class, () ->  {
+        FileNotFoundException exception = assertThrows(FileNotFoundException.class, () ->  {
                     try(IgnitionContainer ignition = new IgnitionContainer("inductiveautomation/ignition:8.1.33")
                             .withGatewayBackup("./src/test/resources/not-a-valid-backup.gwbk", false)
                     ) {
                         ignition.start();
                     }
                 });
-        assertEquals("Container startup failed for image inductiveautomation/ignition:8.1.33", exception.getMessage());
+        assertEquals("gateway backup '.\\src\\test\\resources\\not-a-valid-backup.gwbk' does not exist", exception.getMessage());
     }
 }

--- a/src/test/java/com/mussonindustrial/testcontainers/ignition/GatewayBackupTest.java
+++ b/src/test/java/com/mussonindustrial/testcontainers/ignition/GatewayBackupTest.java
@@ -15,8 +15,7 @@ public class GatewayBackupTest {
     @Test
     public void useGatewayBackup() throws FileNotFoundException {
         try (IgnitionContainer ignition = new IgnitionContainer("inductiveautomation/ignition:8.1.33")
-                .withGatewayBackup("./src/test/resources/backup.gwbk", false)
-                .withExposedPorts(500)) {
+                .withGatewayBackup("./src/test/resources/backup.gwbk", false)) {
             ignition.start();
         }
     }

--- a/src/test/java/com/mussonindustrial/testcontainers/ignition/GatewayBackupTest.java
+++ b/src/test/java/com/mussonindustrial/testcontainers/ignition/GatewayBackupTest.java
@@ -4,6 +4,7 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
 import java.io.FileNotFoundException;
+import java.nio.file.Path;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.parallel.Execution;
 import org.junit.jupiter.api.parallel.ExecutionMode;
@@ -14,21 +15,23 @@ public class GatewayBackupTest {
     @Test
     public void useGatewayBackup() throws FileNotFoundException {
         try (IgnitionContainer ignition = new IgnitionContainer("inductiveautomation/ignition:8.1.33")
-                .withGatewayBackup("./src/test/resources/backup.gwbk", false)) {
+                .withGatewayBackup("./src/test/resources/backup.gwbk", false)
+                .withExposedPorts(500)) {
             ignition.start();
         }
     }
 
     @Test
     public void failWhenGatewayBackupNotPresent() {
+
+        Path backup = Path.of("./src/test/resources/not-a-valid-backup.gwbk");
+
         FileNotFoundException exception = assertThrows(FileNotFoundException.class, () -> {
-            try (IgnitionContainer ignition = new IgnitionContainer("inductiveautomation/ignition:8.1.33")
-                    .withGatewayBackup("./src/test/resources/not-a-valid-backup.gwbk", false)) {
+            try (IgnitionContainer ignition =
+                    new IgnitionContainer("inductiveautomation/ignition:8.1.33").withGatewayBackup(backup, false)) {
                 ignition.start();
             }
         });
-        assertEquals(
-                "gateway backup '.\\src\\test\\resources\\not-a-valid-backup.gwbk' does not exist",
-                exception.getMessage());
+        assertEquals(String.format("gateway backup '%s' does not exist", backup), exception.getMessage());
     }
 }

--- a/src/test/java/com/mussonindustrial/testcontainers/ignition/GatewayBackupTest.java
+++ b/src/test/java/com/mussonindustrial/testcontainers/ignition/GatewayBackupTest.java
@@ -1,36 +1,34 @@
 package com.mussonindustrial.testcontainers.ignition;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+import java.io.FileNotFoundException;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.parallel.Execution;
 import org.junit.jupiter.api.parallel.ExecutionMode;
-
-import java.io.FileNotFoundException;
-
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertThrows;
 
 @Execution(ExecutionMode.CONCURRENT)
 public class GatewayBackupTest {
 
     @Test
     public void useGatewayBackup() throws FileNotFoundException {
-        try (
-                IgnitionContainer ignition = new IgnitionContainer("inductiveautomation/ignition:8.1.33")
-                        .withGatewayBackup("./src/test/resources/backup.gwbk", false)
-        ) {
+        try (IgnitionContainer ignition = new IgnitionContainer("inductiveautomation/ignition:8.1.33")
+                .withGatewayBackup("./src/test/resources/backup.gwbk", false)) {
             ignition.start();
         }
     }
 
     @Test
     public void failWhenGatewayBackupNotPresent() {
-        FileNotFoundException exception = assertThrows(FileNotFoundException.class, () ->  {
-                    try(IgnitionContainer ignition = new IgnitionContainer("inductiveautomation/ignition:8.1.33")
-                            .withGatewayBackup("./src/test/resources/not-a-valid-backup.gwbk", false)
-                    ) {
-                        ignition.start();
-                    }
-                });
-        assertEquals("gateway backup '.\\src\\test\\resources\\not-a-valid-backup.gwbk' does not exist", exception.getMessage());
+        FileNotFoundException exception = assertThrows(FileNotFoundException.class, () -> {
+            try (IgnitionContainer ignition = new IgnitionContainer("inductiveautomation/ignition:8.1.33")
+                    .withGatewayBackup("./src/test/resources/not-a-valid-backup.gwbk", false)) {
+                ignition.start();
+            }
+        });
+        assertEquals(
+                "gateway backup '.\\src\\test\\resources\\not-a-valid-backup.gwbk' does not exist",
+                exception.getMessage());
     }
 }

--- a/src/test/java/com/mussonindustrial/testcontainers/ignition/ModuleTest.java
+++ b/src/test/java/com/mussonindustrial/testcontainers/ignition/ModuleTest.java
@@ -11,7 +11,7 @@ public class ModuleTest {
     @Test
     public void useModuleList() {
         try (IgnitionContainer ignition =
-                new IgnitionContainer("inductiveautomation/ignition:8.1.33").withModule(Module.OPC_UA)) {
+                new IgnitionContainer("inductiveautomation/ignition:8.1.33").withModules(Module.OPC_UA)) {
             ignition.waitingFor(Wait.forLogMessage(".*Processing GATEWAY_MODULES_ENABLED=opc-ua.*\\n", 1));
             ignition.start();
         }

--- a/src/test/java/com/mussonindustrial/testcontainers/ignition/ModuleTest.java
+++ b/src/test/java/com/mussonindustrial/testcontainers/ignition/ModuleTest.java
@@ -5,20 +5,15 @@ import org.junit.jupiter.api.parallel.Execution;
 import org.junit.jupiter.api.parallel.ExecutionMode;
 import org.testcontainers.containers.wait.strategy.Wait;
 
-
 @Execution(ExecutionMode.CONCURRENT)
 public class ModuleTest {
 
     @Test
     public void useModuleList() {
-        try (
-                IgnitionContainer ignition = new IgnitionContainer("inductiveautomation/ignition:8.1.33")
-                        .withModule(Module.OPC_UA)
-                        .withModule(Module.SQL_BRIDGE)
-        ) {
+        try (IgnitionContainer ignition = new IgnitionContainer("inductiveautomation/ignition:8.1.33")
+                .withModule(Module.OPC_UA, Module.SQL_BRIDGE)) {
             ignition.waitingFor(Wait.forLogMessage(".*Processing GATEWAY_MODULES_ENABLED=opc-ua,sql-bridge.*\\n", 1));
             ignition.start();
         }
     }
-
 }

--- a/src/test/java/com/mussonindustrial/testcontainers/ignition/ModuleTest.java
+++ b/src/test/java/com/mussonindustrial/testcontainers/ignition/ModuleTest.java
@@ -11,8 +11,8 @@ public class ModuleTest {
     @Test
     public void useModuleList() {
         try (IgnitionContainer ignition = new IgnitionContainer("inductiveautomation/ignition:8.1.33")
-                .withModule(Module.OPC_UA, Module.SQL_BRIDGE)) {
-            ignition.waitingFor(Wait.forLogMessage(".*Processing GATEWAY_MODULES_ENABLED=opc-ua,sql-bridge.*\\n", 1));
+                .withModule(Module.OPC_UA)) {
+            ignition.waitingFor(Wait.forLogMessage(".*Processing GATEWAY_MODULES_ENABLED=opc-ua.*\\n", 1));
             ignition.start();
         }
     }

--- a/src/test/java/com/mussonindustrial/testcontainers/ignition/ModuleTest.java
+++ b/src/test/java/com/mussonindustrial/testcontainers/ignition/ModuleTest.java
@@ -10,8 +10,8 @@ public class ModuleTest {
 
     @Test
     public void useModuleList() {
-        try (IgnitionContainer ignition = new IgnitionContainer("inductiveautomation/ignition:8.1.33")
-                .withModule(Module.OPC_UA)) {
+        try (IgnitionContainer ignition =
+                new IgnitionContainer("inductiveautomation/ignition:8.1.33").withModule(Module.OPC_UA)) {
             ignition.waitingFor(Wait.forLogMessage(".*Processing GATEWAY_MODULES_ENABLED=opc-ua.*\\n", 1));
             ignition.start();
         }

--- a/src/test/java/com/mussonindustrial/testcontainers/ignition/ModuleTest.java
+++ b/src/test/java/com/mussonindustrial/testcontainers/ignition/ModuleTest.java
@@ -1,0 +1,24 @@
+package com.mussonindustrial.testcontainers.ignition;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.parallel.Execution;
+import org.junit.jupiter.api.parallel.ExecutionMode;
+import org.testcontainers.containers.wait.strategy.Wait;
+
+
+@Execution(ExecutionMode.CONCURRENT)
+public class ModuleTest {
+
+    @Test
+    public void useModuleList() {
+        try (
+                IgnitionContainer ignition = new IgnitionContainer("inductiveautomation/ignition:8.1.33")
+                        .withModule(Module.OPC_UA)
+                        .withModule(Module.SQL_BRIDGE)
+        ) {
+            ignition.waitingFor(Wait.forLogMessage(".*Processing GATEWAY_MODULES_ENABLED=opc-ua,sql-bridge.*\\n", 1));
+            ignition.start();
+        }
+    }
+
+}

--- a/src/test/java/com/mussonindustrial/testcontainers/ignition/PortMappingTest.java
+++ b/src/test/java/com/mussonindustrial/testcontainers/ignition/PortMappingTest.java
@@ -1,36 +1,31 @@
 package com.mussonindustrial.testcontainers.ignition;
 
-import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.parallel.Execution;
-import org.junit.jupiter.api.parallel.ExecutionMode;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 import java.io.IOException;
 import java.net.URI;
 import java.net.http.HttpClient;
 import java.net.http.HttpRequest;
 import java.net.http.HttpResponse;
-
-import static org.junit.jupiter.api.Assertions.assertEquals;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.parallel.Execution;
+import org.junit.jupiter.api.parallel.ExecutionMode;
 
 @Execution(ExecutionMode.CONCURRENT)
 public class PortMappingTest {
 
     @Test
     public void workingMappedHttpPort() {
-        try (
-                IgnitionContainer ignition = new IgnitionContainer("inductiveautomation/ignition:8.1.33")
-        ) {
+        try (IgnitionContainer ignition = new IgnitionContainer("inductiveautomation/ignition:8.1.33")) {
             ignition.start();
             String url = ignition.getGatewayUrl();
             String statusPingUrl = url + "/StatusPing";
 
             HttpClient client = HttpClient.newHttpClient();
-            HttpRequest request = HttpRequest.newBuilder()
-                    .uri(URI.create(statusPingUrl))
-                    .build();
+            HttpRequest request =
+                    HttpRequest.newBuilder().uri(URI.create(statusPingUrl)).build();
 
-            HttpResponse<String> response =
-                    client.send(request, HttpResponse.BodyHandlers.ofString());
+            HttpResponse<String> response = client.send(request, HttpResponse.BodyHandlers.ofString());
 
             assertEquals(response.body(), "{\"state\":\"RUNNING\"}");
         } catch (IOException | InterruptedException e) {

--- a/src/test/java/com/mussonindustrial/testcontainers/ignition/ThirdPartyModuleTest.java
+++ b/src/test/java/com/mussonindustrial/testcontainers/ignition/ThirdPartyModuleTest.java
@@ -1,38 +1,34 @@
 package com.mussonindustrial.testcontainers.ignition;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+import java.io.FileNotFoundException;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.parallel.Execution;
 import org.junit.jupiter.api.parallel.ExecutionMode;
-
-import java.io.FileNotFoundException;
-
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertThrows;
 
 @Execution(ExecutionMode.CONCURRENT)
 public class ThirdPartyModuleTest {
 
     @Test
     public void useThirdPartyModules() throws FileNotFoundException {
-        try (
-                IgnitionContainer ignition = new IgnitionContainer("inductiveautomation/ignition:8.1.33")
-                        .withThirdPartyModule("./src/test/resources/Embr-EventStream-0.4.0.modl")
-                        .withThirdPartyModule("./src/test/resources/Embr-Thermodynamics-0.1.2.modl")
-        ) {
+        try (IgnitionContainer ignition = new IgnitionContainer("inductiveautomation/ignition:8.1.33")
+                .withThirdPartyModule("./src/test/resources/Embr-EventStream-0.4.0.modl")
+                .withThirdPartyModule("./src/test/resources/Embr-Thermodynamics-0.1.2.modl")) {
             ignition.start();
         }
     }
 
     @Test
     public void failWhenModuleNotPresent() {
-        FileNotFoundException exception = assertThrows(FileNotFoundException.class, () ->  {
-            try (
-                    IgnitionContainer ignition = new IgnitionContainer("inductiveautomation/ignition:8.1.33")
-                            .withThirdPartyModule("./src/test/resources/not-a-valid-module.modl")
-            ) {
+        FileNotFoundException exception = assertThrows(FileNotFoundException.class, () -> {
+            try (IgnitionContainer ignition = new IgnitionContainer("inductiveautomation/ignition:8.1.33")
+                    .withThirdPartyModule("./src/test/resources/not-a-valid-module.modl")) {
                 ignition.start();
             }
         });
-        assertEquals("module '.\\src\\test\\resources\\not-a-valid-module.modl' does not exist", exception.getMessage());
+        assertEquals(
+                "module '.\\src\\test\\resources\\not-a-valid-module.modl' does not exist", exception.getMessage());
     }
 }

--- a/src/test/java/com/mussonindustrial/testcontainers/ignition/ThirdPartyModuleTest.java
+++ b/src/test/java/com/mussonindustrial/testcontainers/ignition/ThirdPartyModuleTest.java
@@ -4,11 +4,16 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.parallel.Execution;
 import org.junit.jupiter.api.parallel.ExecutionMode;
 
+import java.io.FileNotFoundException;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
 @Execution(ExecutionMode.CONCURRENT)
 public class ThirdPartyModuleTest {
 
     @Test
-    public void useThirdPartyModules() {
+    public void useThirdPartyModules() throws FileNotFoundException {
         try (
                 IgnitionContainer ignition = new IgnitionContainer("inductiveautomation/ignition:8.1.33")
                         .withThirdPartyModule("./src/test/resources/Embr-EventStream-0.4.0.modl")
@@ -16,5 +21,18 @@ public class ThirdPartyModuleTest {
         ) {
             ignition.start();
         }
+    }
+
+    @Test
+    public void failWhenModuleNotPresent() {
+        FileNotFoundException exception = assertThrows(FileNotFoundException.class, () ->  {
+            try (
+                    IgnitionContainer ignition = new IgnitionContainer("inductiveautomation/ignition:8.1.33")
+                            .withThirdPartyModule("./src/test/resources/not-a-valid-module.modl")
+            ) {
+                ignition.start();
+            }
+        });
+        assertEquals("module '.\\src\\test\\resources\\not-a-valid-module.modl' does not exist", exception.getMessage());
     }
 }

--- a/src/test/java/com/mussonindustrial/testcontainers/ignition/ThirdPartyModuleTest.java
+++ b/src/test/java/com/mussonindustrial/testcontainers/ignition/ThirdPartyModuleTest.java
@@ -4,9 +4,12 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
 import java.io.FileNotFoundException;
+import java.nio.file.Path;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.parallel.Execution;
 import org.junit.jupiter.api.parallel.ExecutionMode;
+import org.testcontainers.containers.wait.strategy.Wait;
+import org.testcontainers.containers.wait.strategy.WaitAllStrategy;
 
 @Execution(ExecutionMode.CONCURRENT)
 public class ThirdPartyModuleTest {
@@ -16,19 +19,28 @@ public class ThirdPartyModuleTest {
         try (IgnitionContainer ignition = new IgnitionContainer("inductiveautomation/ignition:8.1.33")
                 .withThirdPartyModule("./src/test/resources/Embr-EventStream-0.4.0.modl")
                 .withThirdPartyModule("./src/test/resources/Embr-Thermodynamics-0.1.2.modl")) {
+
+            WaitAllStrategy waitStrategy = new WaitAllStrategy();
+            waitStrategy = waitStrategy
+                    .withStrategy(Wait.forLogMessage(".*Embr Event Stream.*\\n", 1))
+                    .withStrategy(Wait.forLogMessage(".*Embr Thermodynamics.*\\n", 1));
+
+            ignition.waitingFor(waitStrategy);
             ignition.start();
         }
     }
 
     @Test
     public void failWhenModuleNotPresent() {
+
+        Path module = Path.of("./src/test/resources/not-a-valid-module.modl");
+
         FileNotFoundException exception = assertThrows(FileNotFoundException.class, () -> {
-            try (IgnitionContainer ignition = new IgnitionContainer("inductiveautomation/ignition:8.1.33")
-                    .withThirdPartyModule("./src/test/resources/not-a-valid-module.modl")) {
+            try (IgnitionContainer ignition =
+                    new IgnitionContainer("inductiveautomation/ignition:8.1.33").withThirdPartyModule(module)) {
                 ignition.start();
             }
         });
-        assertEquals(
-                "module '.\\src\\test\\resources\\not-a-valid-module.modl' does not exist", exception.getMessage());
+        assertEquals(String.format("module '%s' does not exist", module), exception.getMessage());
     }
 }

--- a/src/test/java/com/mussonindustrial/testcontainers/ignition/ThirdPartyModuleTest.java
+++ b/src/test/java/com/mussonindustrial/testcontainers/ignition/ThirdPartyModuleTest.java
@@ -17,8 +17,9 @@ public class ThirdPartyModuleTest {
     @Test
     public void useThirdPartyModules() throws FileNotFoundException {
         try (IgnitionContainer ignition = new IgnitionContainer("inductiveautomation/ignition:8.1.33")
-                .withThirdPartyModule("./src/test/resources/Embr-EventStream-0.4.0.modl")
-                .withThirdPartyModule("./src/test/resources/Embr-Thermodynamics-0.1.2.modl")) {
+                .withThirdPartyModules(
+                        "./src/test/resources/Embr-EventStream-0.4.0.modl",
+                        "./src/test/resources/Embr-Thermodynamics-0.1.2.modl")) {
 
             WaitAllStrategy waitStrategy = new WaitAllStrategy();
             waitStrategy = waitStrategy
@@ -37,7 +38,7 @@ public class ThirdPartyModuleTest {
 
         FileNotFoundException exception = assertThrows(FileNotFoundException.class, () -> {
             try (IgnitionContainer ignition =
-                    new IgnitionContainer("inductiveautomation/ignition:8.1.33").withThirdPartyModule(module)) {
+                    new IgnitionContainer("inductiveautomation/ignition:8.1.33").withThirdPartyModules(module)) {
                 ignition.start();
             }
         });


### PR DESCRIPTION
- Remove inner Environment Variables and Runtime argument classes.
- Add validation that gateway backup and third-party modules exist.
- Add `Path` overloads for gateway backup and third-party module assignments.
- Change from modules/third-party modules from arrays to sets.
- Change `getGatewayHttpPort` and friends to `getMapped~PortName~`.
- Add `spotless` formatting.