### PR TITLE
Remove default credentials

### DIFF
--- a/src/main/java/com/mussonindustrial/testcontainers/ignition/IgnitionContainer.java
+++ b/src/main/java/com/mussonindustrial/testcontainers/ignition/IgnitionContainer.java
@@ -580,8 +580,8 @@ public class IgnitionContainer extends GenericContainer<IgnitionContainer> {
     private void applyEnvironmentVariables() {
         if (licenseAccepted) addEnv("ACCEPT_IGNITION_EULA", "Y");
         addEnv("DISABLE_QUICKSTART", String.valueOf(!quickStartEnabled));
-        addEnv("GATEWAY_ADMIN_USERNAME", username);
-        addEnv("GATEWAY_ADMIN_PASSWORD", password);
+        if (username != null) addEnv("GATEWAY_ADMIN_USERNAME", username);
+        if (password != null) addEnv("GATEWAY_ADMIN_PASSWORD", password);
 
         addEnv("GATEWAY_GAN_PORT", String.valueOf(GAN_PORT));
         addEnv("GATEWAY_HTTP_PORT", String.valueOf(GATEWAY_PORT));

--- a/src/main/java/com/mussonindustrial/testcontainers/ignition/IgnitionContainer.java
+++ b/src/main/java/com/mussonindustrial/testcontainers/ignition/IgnitionContainer.java
@@ -44,9 +44,9 @@ public class IgnitionContainer extends GenericContainer<IgnitionContainer> {
 
     private static final String INSTALL_DIR = "/usr/local/bin/ignition";
 
-    private String username = "admin";
+    private String username;
 
-    private String password = "password";
+    private String password;
 
     private Integer uid;
 

--- a/src/test/java/com/mussonindustrial/testcontainers/ignition/IgnitionContainerTest.java
+++ b/src/test/java/com/mussonindustrial/testcontainers/ignition/IgnitionContainerTest.java
@@ -109,6 +109,7 @@ public class IgnitionContainerTest {
                 .withThirdPartyModules(
                         "./src/test/resources/Embr-EventStream-0.4.0.modl",
                         "./src/test/resources/Embr-Thermodynamics-0.1.2.modl")
+                .withCredentials("admin", "password")
                 .acceptLicense()) {
 
             WaitAllStrategy waitStrategy = new WaitAllStrategy();
@@ -130,6 +131,7 @@ public class IgnitionContainerTest {
         FileNotFoundException exception = assertThrows(FileNotFoundException.class, () -> {
             try (IgnitionContainer ignition = new IgnitionContainer(image.getDockerImageName())
                     .withThirdPartyModules(module)
+                    .withCredentials("admin", "password")
                     .acceptLicense()) {
 
                 ignition.start();


### PR DESCRIPTION
Applying default credentials can mess with user source settings when restoring from a gateway backup, so should only be applied if a user is manually making the decision to. 