### PR TITLE
v0.4.1

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,5 +1,5 @@
 [versions]
-testcontainers = "1.20.1"
+testcontainers = "1.20.2"
 junit-platform = "1.11.0"
 junit-jupiter = "5.11.0"
 slf4j = "2.0.16"

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,6 +1,6 @@
 [versions]
 testcontainers = "1.20.2"
-junit-platform = "1.11.0"
+junit-platform = "1.11.2"
 junit-jupiter = "5.11.2"
 slf4j = "2.0.16"
 jreleaser = "1.14.0"

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,7 +1,7 @@
 [versions]
 testcontainers = "1.20.2"
 junit-platform = "1.11.0"
-junit-jupiter = "5.11.0"
+junit-jupiter = "5.11.2"
 slf4j = "2.0.16"
 jreleaser = "1.14.0"
 spotless = "6.25.0"


### PR DESCRIPTION
- Bumps [org.junit.platform:junit-platform-launcher](https://github.com/junit-team/junit5) from 1.11.0 to 1.11.2.
- Updates `org.junit.jupiter:junit-jupiter` from 5.11.0 to 5.11.2
- Bumps [org.testcontainers:testcontainers](https://github.com/testcontainers/testcontainers-java) from 1.20.1 to 1.20.2.